### PR TITLE
Fixed string interpolation for complex expressions

### DIFF
--- a/EPS.ps1
+++ b/EPS.ps1
@@ -175,7 +175,7 @@ function Compile-Raw{
             }
             
             '<%=' {
-              $line += ($insert_cmd + '"' + $content.trim() + '"')
+              $line += ($insert_cmd + '"$(' + $content.trim() + ')"')
             }
             
             '<%#' { }


### PR DESCRIPTION
Hello!

This fix allows to write expressions like 

```
<%= $data.list[0].name %>
```

Maybe it is not the best fix, and replacing the whole string interpolation by an Invoke-Command would make more sense. But it is an easy fix and should not break anything.
